### PR TITLE
fix: icon size on store page

### DIFF
--- a/web/features/components/Icon.tsx
+++ b/web/features/components/Icon.tsx
@@ -31,7 +31,7 @@ export const Icon = ({ src, alt, size = 120, className }: IconProps) => {
       }}
     >
       {!hasError ? (
-        <img src={src} alt={alt} className="w-full h-full object-cover" onError={() => setHasError(true)} />
+        <img src={src} alt={alt} className="w-100 h-full object-cover" onError={() => setHasError(true)} />
       ) : (
         <span>{getInitials(alt)}</span>
       )}


### PR DESCRIPTION
<img width="1847" height="1028" alt="Screenshot from 2025-08-05 14-57-33" src="https://github.com/user-attachments/assets/1d171f70-8d3f-48f7-b57f-c4a1c8ecf044" />
